### PR TITLE
Support extend definitions

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -342,6 +342,7 @@ type Object struct {
 	PrivateDescription string `json:"description"`
 	IsTypeOf           IsTypeOfFn
 	AppliedDirectives  []*AppliedDirective `json:"appliedDirectives"`
+	Extend             bool                `json:"extend"`
 
 	typeConfig            ObjectConfig
 	initialisedFields     bool
@@ -378,6 +379,7 @@ type ObjectConfig struct {
 	IsTypeOf          IsTypeOfFn          `json:"isTypeOf"`
 	Description       string              `json:"description"`
 	AppliedDirectives []*AppliedDirective `json:"appliedDirectives"`
+	Extend            bool                `json:"extend"`
 }
 
 type FieldsThunk func() Fields
@@ -400,6 +402,7 @@ func NewObject(config ObjectConfig) *Object {
 	objectType.PrivateDescription = config.Description
 	objectType.IsTypeOf = config.IsTypeOf
 	objectType.AppliedDirectives = config.AppliedDirectives
+	objectType.Extend = config.Extend
 	objectType.typeConfig = config
 
 	return objectType
@@ -703,6 +706,7 @@ type Interface struct {
 	PrivateDescription string `json:"description"`
 	ResolveType        ResolveTypeFn
 	AppliedDirectives  []*AppliedDirective `json:"appliedDirectives"`
+	Extend             bool                `json:"extend"`
 
 	typeConfig        InterfaceConfig
 	initialisedFields bool
@@ -715,6 +719,7 @@ type InterfaceConfig struct {
 	ResolveType       ResolveTypeFn
 	Description       string `json:"description"`
 	AppliedDirectives []*AppliedDirective
+	Extend            bool `json:"extend"`
 }
 
 // ResolveTypeParams Params for ResolveTypeFn()
@@ -747,6 +752,7 @@ func NewInterface(config InterfaceConfig) *Interface {
 	it.PrivateDescription = config.Description
 	it.ResolveType = config.ResolveType
 	it.AppliedDirectives = config.AppliedDirectives
+	it.Extend = config.Extend
 	it.typeConfig = config
 
 	return it
@@ -821,6 +827,7 @@ type Union struct {
 	PrivateDescription string `json:"description"`
 	ResolveType        ResolveTypeFn
 	AppliedDirectives  []*AppliedDirective
+	Extend             bool `json:"extend"`
 
 	typeConfig      UnionConfig
 	initalizedTypes bool
@@ -838,6 +845,7 @@ type UnionConfig struct {
 	ResolveType       ResolveTypeFn
 	Description       string `json:"description"`
 	AppliedDirectives []*AppliedDirective
+	Extend            bool `json:"extend"`
 }
 
 func NewUnion(config UnionConfig) *Union {
@@ -853,6 +861,7 @@ func NewUnion(config UnionConfig) *Union {
 	objectType.PrivateDescription = config.Description
 	objectType.ResolveType = config.ResolveType
 	objectType.AppliedDirectives = config.AppliedDirectives
+	objectType.Extend = config.Extend
 
 	objectType.typeConfig = config
 
@@ -956,6 +965,7 @@ type Enum struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
 	AppliedDirectives  []*AppliedDirective
+	Extend             bool `json:"extend"`
 
 	enumConfig   EnumConfig
 	values       []*EnumValueDefinition
@@ -976,6 +986,7 @@ type EnumConfig struct {
 	Values            EnumValueConfigMap `json:"values"`
 	Description       string             `json:"description"`
 	AppliedDirectives []*AppliedDirective
+	Extend            bool `json:"extend"`
 }
 type EnumValueDefinition struct {
 	Name              string      `json:"name"`
@@ -996,6 +1007,7 @@ func NewEnum(config EnumConfig) *Enum {
 	gt.PrivateName = config.Name
 	gt.PrivateDescription = config.Description
 	gt.AppliedDirectives = config.AppliedDirectives
+	gt.Extend = config.Extend
 
 	if gt.values, gt.err = gt.defineEnumValues(config.Values); gt.err != nil {
 		return gt
@@ -1136,6 +1148,7 @@ type InputObject struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
 	AppliedDirectives  []*AppliedDirective
+	Extend             bool `json:"extend"`
 
 	typeConfig InputObjectConfig
 	fields     InputObjectFieldMap
@@ -1176,6 +1189,7 @@ type InputObjectConfig struct {
 	Name              string      `json:"name"`
 	Fields            interface{} `json:"fields"`
 	Description       string      `json:"description"`
+	Extend            bool        `json:"extend"`
 	AppliedDirectives []*AppliedDirective
 }
 
@@ -1188,6 +1202,7 @@ func NewInputObject(config InputObjectConfig) *InputObject {
 	gt.PrivateName = config.Name
 	gt.PrivateDescription = config.Description
 	gt.AppliedDirectives = config.AppliedDirectives
+	gt.Extend = config.Extend
 	gt.typeConfig = config
 	return gt
 }

--- a/federation/federation_test.go
+++ b/federation/federation_test.go
@@ -31,6 +31,24 @@ func buildSubgraph(includeQuery bool) (graphql.Schema, error) {
 		},
 	})
 
+	userType := graphql.NewObject(graphql.ObjectConfig{
+		Name:   "User",
+		Extend: true,
+		Fields: graphql.Fields{
+			"id": &graphql.Field{
+				Name: "id",
+				Type: graphql.NewNonNull(graphql.ID),
+			},
+			"purchasedItems": &graphql.Field{
+				Name: "purchasedItems",
+				Type: graphql.NewList(productType),
+			},
+		},
+		AppliedDirectives: []*graphql.AppliedDirective{
+			federation.KeyAppliedDirective("id", true),
+		},
+	})
+
 	var schemaConfig graphql.SchemaConfig
 	if includeQuery {
 		schemaConfig = graphql.SchemaConfig{
@@ -53,12 +71,14 @@ func buildSubgraph(includeQuery bool) (graphql.Schema, error) {
 			}),
 			Types: []graphql.Type{
 				productType,
+				userType,
 			},
 		}
 	} else {
 		schemaConfig = graphql.SchemaConfig{
 			Types: []graphql.Type{
 				productType,
+				userType,
 			},
 		}
 	}
@@ -165,11 +185,16 @@ type Query {
   product(id: ID!): Product
 }
 
+extend type User @key(fields: "id", resolvable: true) {
+  id: ID!
+  purchasedItems: [Product]
+}
+
 type _Service {
   sdl: String!
 }
 
-union _Entity = Product
+union _Entity = Product | User
 
 "String-serialized scalar represents a set of fields that's passed to a federated directive, such as @key, @requires, or @provides"
 scalar FieldSet
@@ -279,11 +304,16 @@ type Query {
   _service: _Service
 }
 
+extend type User @key(fields: "id", resolvable: true) {
+  id: ID!
+  purchasedItems: [Product]
+}
+
 type _Service {
   sdl: String!
 }
 
-union _Entity = Product
+union _Entity = Product | User
 
 "String-serialized scalar represents a set of fields that's passed to a federated directive, such as @key, @requires, or @provides"
 scalar FieldSet

--- a/federation/schema_printer.go
+++ b/federation/schema_printer.go
@@ -123,6 +123,13 @@ func printAppliedDirectives(appliedDirectives []*graphql.AppliedDirective, depre
 	}
 }
 
+func printType(typeName string, name string, extend bool, out *strings.Builder) {
+	if extend {
+		typeName = "extend " + typeName
+	}
+	fmt.Fprintf(out, "%s %s", typeName, name)
+}
+
 func sortAppliedDirectives(appliedDirectives []*graphql.AppliedDirective) []*graphql.AppliedDirective {
 	sorted := make([]*graphql.AppliedDirective, 0, len(appliedDirectives))
 	for _, v := range appliedDirectives {
@@ -181,7 +188,7 @@ func printEnumDefinitions(enums []*graphql.Enum, out *strings.Builder) {
 
 	for _, enum := range enums {
 		printDescription(enum.Description(), 0, out)
-		fmt.Fprintf(out, "enum %s", enum.Name())
+		printType("enum", enum.Name(), enum.Extend, out)
 		printAppliedDirectives(enum.AppliedDirectives, "", out)
 		out.WriteString(" {\n")
 
@@ -212,7 +219,7 @@ func printInputObjectDefinitions(inputObjects []*graphql.InputObject, out *strin
 
 	for _, inputObject := range inputObjects {
 		printDescription(inputObject.Description(), 0, out)
-		fmt.Fprintf(out, "input %s", inputObject.Name())
+		printType("input", inputObject.Name(), inputObject.Extend, out)
 		printAppliedDirectives(inputObject.AppliedDirectives, "", out)
 		out.WriteString(" {\n")
 		printInputObjectFieldDefinitions(inputObject.Fields(), out)
@@ -264,7 +271,7 @@ func printObjectDefinitions(objects []*graphql.Object, out *strings.Builder) {
 
 	for _, object := range objects {
 		printDescription(object.Description(), 0, out)
-		fmt.Fprintf(out, "type %s", object.Name())
+		printType("type", object.Name(), object.Extend, out)
 		if len(object.Interfaces()) > 0 {
 			interfaces := make([]string, 0, len(object.Interfaces()))
 			for _, i := range object.Interfaces() {
@@ -317,7 +324,7 @@ func printUnionDefinitions(unions []*graphql.Union, out *strings.Builder) {
 
 	for _, union := range unions {
 		printDescription(union.Description(), 0, out)
-		fmt.Fprintf(out, "union %s", union.Name())
+		printType("union", union.Name(), union.Extend, out)
 		printAppliedDirectives(union.AppliedDirectives, "", out)
 		typeNames := make([]string, 0, len(union.Types()))
 		for _, t := range union.Types() {


### PR DESCRIPTION
If a `type`, `enum`, `input`, `interface` is defined in the base-schema, a subgraph should extend this definition with the extend keyword.

e.g. I tried using graphql-go as a subgraph for [wundergraph/graphql-go-tools](github.com/wundergraph/graphql-go-tools). While loading the subgraph an error occured, that a `[typeName]` can only be defined once.